### PR TITLE
Add double counting detection notebook

### DIFF
--- a/double_counting_isolation.ipynb
+++ b/double_counting_isolation.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1ac3e6dc",
+   "metadata": {},
+   "source": [
+    "# Deteksi Double Counting dengan Isolation Forest\n",
+    "\n",
+    "Notebook ini menerapkan pendekatan dua tahap:\n",
+    "1. Mengidentifikasi data klaim yang diduga double counting menggunakan Isolation Forest.\n",
+    "2. Menghitung estimasi cadangan klaim dengan metode Chain Ladder dan Bornhuetter‑Ferguson pada data mentah dan data yang telah dibersihkan dari anomali.\n",
+    "\n",
+    "Dataset: `claims_company_style_with_reported_year.csv`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8592cab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install chainladder pandas scikit-learn matplotlib seaborn --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b88c2c9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.ensemble import IsolationForest\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a79c6a00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('claims_company_style_with_reported_year.csv')\n",
+    "print('Shape:', df.shape)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fddd972f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fitur untuk deteksi anomali\n",
+    "a_features = df[['incremental_paid','incremental_incurred','cumulative_paid','cumulative_incurred']]\n",
+    "iso = IsolationForest(contamination=0.02, random_state=42)\n",
+    "df['anomaly'] = iso.fit_predict(a_features)\n",
+    "\n",
+    "# Visualisasi skor anomali\n",
+    "sns.histplot(iso.decision_function(a_features), bins=30)\n",
+    "plt.xlabel('Isolation Forest score')\n",
+    "plt.show()\n",
+    "\n",
+    "print('Jumlah anomali:', (df['anomaly']==-1).sum())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8aee4dcf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_df = df[df['anomaly'] != -1].copy()\n",
+    "print('Data bersih:', clean_df.shape)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbe744b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_triangle(data):\n",
+    "    tri = data.pivot_table(index='accident_year', columns='development_year', values='cumulative_paid', aggfunc='sum').sort_index()\n",
+    "    return tri\n",
+    "\n",
+    "def chain_ladder(triangle):\n",
+    "    dev_periods = triangle.columns.tolist()\n",
+    "    n = len(dev_periods)\n",
+    "    factors = []\n",
+    "    for j in range(n-1):\n",
+    "        numer = triangle.loc[:, dev_periods[j+1]].iloc[:-j-1].sum()\n",
+    "        denom = triangle.loc[:, dev_periods[j]].iloc[:-j-1].sum()\n",
+    "        factors.append(numer/denom)\n",
+    "    factors.append(1.0)\n",
+    "    ultimate = {}\n",
+    "    for i, row in triangle.iterrows():\n",
+    "        last_dev = row.last_valid_index()\n",
+    "        idx = dev_periods.index(last_dev)\n",
+    "        factor_prod = np.prod(factors[idx:])\n",
+    "        ultimate[i] = row[last_dev] * factor_prod\n",
+    "    return pd.Series(ultimate), factors\n",
+    "\n",
+    "def bornhuetter_ferguson(triangle, exposures, factors):\n",
+    "    dev_periods = triangle.columns.tolist()\n",
+    "    lr = triangle.iloc[:,-1].sum() / exposures.sum()\n",
+    "    ultimates = {}\n",
+    "    cum_factors = np.cumprod(factors)\n",
+    "    for i, row in triangle.iterrows():\n",
+    "        last_dev = row.last_valid_index()\n",
+    "        idx = dev_periods.index(last_dev)\n",
+    "        percent_reported = 1.0/cum_factors[idx]\n",
+    "        expected = exposures.loc[i] * lr\n",
+    "        ultimates[i] = row[last_dev] + expected*(1-percent_reported)\n",
+    "    return pd.Series(ultimates)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "706d2de0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "triangle_raw = build_triangle(df)\n",
+    "triangle_clean = build_triangle(clean_df)\n",
+    "\n",
+    "exposure = df.groupby('accident_year')['exposure_premium'].sum()\n",
+    "\n",
+    "cl_raw, factors = chain_ladder(triangle_raw)\n",
+    "cl_clean, _ = chain_ladder(triangle_clean)\n",
+    "\n",
+    "bf_raw = bornhuetter_ferguson(triangle_raw, exposure, factors)\n",
+    "bf_clean = bornhuetter_ferguson(triangle_clean, exposure, factors)\n",
+    "\n",
+    "result = pd.DataFrame({\n",
+    "    'CL_raw': cl_raw,\n",
+    "    'CL_clean': cl_clean,\n",
+    "    'BF_raw': bf_raw,\n",
+    "    'BF_clean': bf_clean\n",
+    "})\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ab47fee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.plot(kind='bar', figsize=(12,6))\n",
+    "plt.ylabel('Ultimate Estimate')\n",
+    "plt.title('Perbandingan Estimasi Cadangan per Accident Year')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f95b1c2",
+   "metadata": {},
+   "source": [
+    "Notebook selesai."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new notebook `double_counting_isolation.ipynb` to detect double counting with Isolation Forest
- compare Chain Ladder and Bornhuetter-Ferguson estimates on raw vs cleaned data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d38879da4832f8556c1ff8e63e2bd